### PR TITLE
Force to use linear sampling

### DIFF
--- a/Assets/Kino/Motion/Script/FrameBlendingFilter.cs
+++ b/Assets/Kino/Motion/Script/FrameBlendingFilter.cs
@@ -141,8 +141,8 @@ namespace Kino
                 {
                     Release();
 
-                    lumaTexture = RenderTexture.GetTemporary(source.width, source.height, 0, RenderTextureFormat.R8);
-                    chromaTexture = RenderTexture.GetTemporary(source.width, source.height, 0, RenderTextureFormat.R8);
+                    lumaTexture = RenderTexture.GetTemporary(source.width, source.height, 0, RenderTextureFormat.R8, RenderTextureReadWrite.Linear);
+                    chromaTexture = RenderTexture.GetTemporary(source.width, source.height, 0, RenderTextureFormat.R8, RenderTextureReadWrite.Linear);
 
                     lumaTexture.filterMode = FilterMode.Point;
                     chromaTexture.filterMode = FilterMode.Point;

--- a/Assets/Kino/Motion/Script/ReconstructionFilter.cs
+++ b/Assets/Kino/Motion/Script/ReconstructionFilter.cs
@@ -152,7 +152,8 @@ namespace Kino
             {
                 var w = source.width / divider;
                 var h = source.height / divider;
-                var rt = RenderTexture.GetTemporary(w, h, 0, format);
+                var linear = RenderTextureReadWrite.Linear;
+                var rt = RenderTexture.GetTemporary(w, h, 0, format, linear);
                 rt.filterMode = FilterMode.Point;
                 return rt;
             }


### PR DESCRIPTION
- Changed to disable color space convertion with the temporary render textures. This is required to avoid an issue with AMD GPUs that is only reproducible on DX9.